### PR TITLE
[#MD10712] - Arbitrary fields

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -20,7 +20,7 @@ Jeweler::Tasks.new do |gem|
   gem.summary = %Q{Simple interface to zoho api}
   gem.description = %Q{Simple interface to zoho api}
   gem.email = "jkentonwhite@gmail.com"
-  gem.authors = ["KentonWhite"]
+  gem.authors = ["KentonWhite", "NicholasMartin", "Xymist"]
   # dependencies defined in Gemfile
 end
 Jeweler::RubygemsDotOrgTasks.new

--- a/lib/zohoho/account.rb
+++ b/lib/zohoho/account.rb
@@ -8,5 +8,15 @@ module Zohoho
       "Billing Country","Shipping Country", "Description", "Agreement",
       "Description", "Website", "Annual Revenue"
     ]
+
+    def initialize(elements = {})
+      # The default fields are expected by Zoho
+      DEFAULT_FIELDS.each do |field|
+        self[field] = elements.delete(field) || ''
+      end
+      # It is possible to pass arbitrary additional elements to an account,
+      # which will populate custom fields.
+      elements.each { |key, value| self[key] = value } unless elements.empty?
+    end
   end
 end

--- a/lib/zohoho/account.rb
+++ b/lib/zohoho/account.rb
@@ -1,11 +1,22 @@
-  module Zohoho
+module Zohoho
+  # An account represents a paying customer in the CRM, generally a company.
   class Account < ZohoObject
-    @@myFields = ["ACCOUNTID", "Account Name", "Phone", "Fax", "Employees", "Billing Street", "Shipping Street", "Billing City", "Shipping City", "Billing State", "Shipping State", "Billing Code", "Shipping Code", "Billing Country","Shipping Country", "Description", "Agreement", "Description", "Website", "Annual Revenue" ]
+    DEFAULT_FIELDS = [
+      "ACCOUNTID", "Account Name", "Phone", "Fax", "Employees",
+      "Billing Street", "Shipping Street", "Billing City", "Shipping City",
+      "Billing State", "Shipping State", "Billing Code", "Shipping Code",
+      "Billing Country","Shipping Country", "Description", "Agreement",
+      "Description", "Website", "Annual Revenue"
+    ]
 
-    def initialize(h={})
-      @@myFields.each do |f|
-        self[f] = h[f] ||''
-        end
+    def initialize(elements = {})
+      # The default fields are expected by Zoho
+      DEFAULT_FIELDS.each do |field|
+        self[field] = elements.delete(field) || ''
+      end
+      # It is possible to pass arbitrary additional elements to an account,
+      # which will populate custom fields.
+      elements.each { |key, value| self[key] = value } unless elements.empty?
     end
   end
 end

--- a/lib/zohoho/account.rb
+++ b/lib/zohoho/account.rb
@@ -8,15 +8,5 @@ module Zohoho
       "Billing Country","Shipping Country", "Description", "Agreement",
       "Description", "Website", "Annual Revenue"
     ]
-
-    def initialize(elements = {})
-      # The default fields are expected by Zoho
-      DEFAULT_FIELDS.each do |field|
-        self[field] = elements.delete(field) || ''
-      end
-      # It is possible to pass arbitrary additional elements to an account,
-      # which will populate custom fields.
-      elements.each { |key, value| self[key] = value } unless elements.empty?
-    end
   end
 end

--- a/lib/zohoho/contact.rb
+++ b/lib/zohoho/contact.rb
@@ -11,5 +11,15 @@ module Zohoho
       "Salutation", "Email3", "Lead Source Detail", "Registration Status",
       "Email Opt Out", "Secondary Email", "Website"
     ]
+
+    def initialize(elements = {})
+      # The default fields are expected by Zoho
+      DEFAULT_FIELDS.each do |field|
+        self[field] = elements.delete(field) || ''
+      end
+      # It is possible to pass arbitrary additional elements to a contact, which
+      # will populate custom fields.
+      elements.each { |key, value| self[key] = value } unless elements.empty?
+    end
   end
 end

--- a/lib/zohoho/contact.rb
+++ b/lib/zohoho/contact.rb
@@ -11,15 +11,5 @@ module Zohoho
       "Salutation", "Email3", "Lead Source Detail", "Registration Status",
       "Email Opt Out", "Secondary Email", "Website"
     ]
-
-    def initialize(elements = {})
-      # The default fields are expected by Zoho
-      DEFAULT_FIELDS.each do |field|
-        self[field] = elements.delete(field) || ''
-      end
-      # It is possible to pass arbitrary additional elements to a contact, which
-      # will populate custom fields.
-      elements.each { |key, value| self[key] = value } unless elements.empty?
-    end
   end
 end

--- a/lib/zohoho/contact.rb
+++ b/lib/zohoho/contact.rb
@@ -1,11 +1,25 @@
 module Zohoho
+  # Represents a Contact, or an individual within the CRM.
   class Contact < ZohoObject
-    @@myFields = ["ACCOUNTID", "Contact Owner", "Lead Source", "First Name", "Last Name", "Email", "Title", "Department", "Phone", "Home Phone", "Fax", "Mobile", "Date of Birth", "Assistant", "Asst Phone", "Reports To", "Mailing Street", "Other Street", "Mailing City", "Other City", "Mailing State", "Other State", "Mailing Zip", "Other Zip", "Mailing Country", "Other Country", "Description", "Skype ID", "Salutation", "Email3", "Lead Source Detail", "Registration Status", "Email Opt Out", "Secondary Email", "Website"]
+    DEFAULT_FIELDS = [
+      "ACCOUNTID", "Contact Owner", "Lead Source", "First Name", "Last Name",
+      "Email", "Title", "Department", "Phone", "Home Phone", "Fax", "Mobile",
+      "Date of Birth", "Assistant", "Asst Phone", "Reports To",
+      "Mailing Street", "Other Street", "Mailing City", "Other City",
+      "Mailing State", "Other State", "Mailing Zip", "Other Zip",
+      "Mailing Country", "Other Country", "Description", "Skype ID",
+      "Salutation", "Email3", "Lead Source Detail", "Registration Status",
+      "Email Opt Out", "Secondary Email", "Website"
+    ]
 
-    def initialize(h ={})
-      @@myFields.each do |f|
-        self[f] = h[f] ||''
+    def initialize(elements = {})
+      # The default fields are expected by Zoho
+      DEFAULT_FIELDS.each do |field|
+        self[field] = elements.delete(field) || ''
       end
+      # It is possible to pass arbitrary additional elements to a contact, which
+      # will populate custom fields.
+      elements.each { |key, value| self[key] = value } unless elements.empty?
     end
   end
 end

--- a/lib/zohoho/lead.rb
+++ b/lib/zohoho/lead.rb
@@ -7,15 +7,5 @@ module Zohoho
       "Salutation", "Street", "City", "State", "Zip Code", "Country",
       "Description", "Annual Revenue", "Rating"
     ]
-
-    def initialize(elements = {})
-      # The default fields are expected by Zoho
-      DEFAULT_FIELDS.each do |field|
-        self[field] = elements.delete(field) || ''
-      end
-      # It is possible to pass arbitrary additional elements to a lead,
-      # which will populate custom fields.
-      elements.each { |key, value| self[key] = value } unless elements.empty?
-    end
   end
 end

--- a/lib/zohoho/lead.rb
+++ b/lib/zohoho/lead.rb
@@ -7,5 +7,15 @@ module Zohoho
       "Salutation", "Street", "City", "State", "Zip Code", "Country",
       "Description", "Annual Revenue", "Rating"
     ]
+
+    def initialize(elements = {})
+      # The default fields are expected by Zoho
+      DEFAULT_FIELDS.each do |field|
+        self[field] = elements.delete(field) || ''
+      end
+      # It is possible to pass arbitrary additional elements to a lead,
+      # which will populate custom fields.
+      elements.each { |key, value| self[key] = value } unless elements.empty?
+    end
   end
 end

--- a/lib/zohoho/lead.rb
+++ b/lib/zohoho/lead.rb
@@ -1,13 +1,21 @@
 module Zohoho
   class Lead < ZohoObject
-    @@myFields = ["Company", "First Name", "Last Name", ":Designation", "Email", "Phone", "Fax", "Mobile", "Website", "Lead Source", "Lead Status", "Industry", "No of Employees",
-    "Annual Revenue", "Email Opt Out", "Skype ID", "Salutation", "Street", "City", "State", "Zip Code", "Country", "Description", "Annual Revenue", "Rating"]
-   #attr_accessor *@@myFields
+    DEFAULT_FIELDS = [
+      "Company", "First Name", "Last Name", ":Designation", "Email", "Phone",
+      "Fax", "Mobile", "Website", "Lead Source", "Lead Status", "Industry",
+      "No of Employees", "Annual Revenue", "Email Opt Out", "Skype ID",
+      "Salutation", "Street", "City", "State", "Zip Code", "Country",
+      "Description", "Annual Revenue", "Rating"
+    ]
 
-    def initialize(h={})
-      @@myFields.each do |f|
-        self[f] = h[f] ||''
-        end
+    def initialize(elements = {})
+      # The default fields are expected by Zoho
+      DEFAULT_FIELDS.each do |field|
+        self[field] = elements.delete(field) || ''
+      end
+      # It is possible to pass arbitrary additional elements to a lead,
+      # which will populate custom fields.
+      elements.each { |key, value| self[key] = value } unless elements.empty?
     end
   end
 end

--- a/lib/zohoho/zoho_object.rb
+++ b/lib/zohoho/zoho_object.rb
@@ -1,5 +1,17 @@
 module Zohoho
   class ZohoObject < Hash
+    DEFAULT_FIELDS = []
+
+    def initialize(elements = {})
+      # The default fields are expected by Zoho
+      DEFAULT_FIELDS.each do |field|
+        self[field] = elements.delete(field) || ''
+      end
+      # It is possible to pass arbitrary additional elements to an object,
+      # which will populate custom fields.
+      elements.each { |key, value| self[key] = value } unless elements.empty?
+    end
+
     def xmlData
       parse_data
     end

--- a/lib/zohoho/zoho_object.rb
+++ b/lib/zohoho/zoho_object.rb
@@ -9,13 +9,13 @@ module Zohoho
       self.class.to_s.split('::').last + "s" || ''
     end
 
-
     protected
+
     def parse_data
-      fl = self.map {|e| Hash['val', (e[0]), 'content', (e[1]||'')]}
+      fl = self.map { |e| Hash['val', (e[0]), 'content', (e[1]||'')] }
       row = Hash['no', '1', 'FL', fl]
       data = Hash['row', row]
-      XmlSimple.xml_out(data, :RootName => data_name)
+      XmlSimple.xml_out(data, RootName: data_name)
     end
   end
 end

--- a/lib/zohoho/zoho_object.rb
+++ b/lib/zohoho/zoho_object.rb
@@ -1,17 +1,5 @@
 module Zohoho
   class ZohoObject < Hash
-    DEFAULT_FIELDS = []
-
-    def initialize(elements = {})
-      # The default fields are expected by Zoho
-      DEFAULT_FIELDS.each do |field|
-        self[field] = elements.delete(field) || ''
-      end
-      # It is possible to pass arbitrary additional elements to an object,
-      # which will populate custom fields.
-      elements.each { |key, value| self[key] = value } unless elements.empty?
-    end
-
     def xmlData
       parse_data
     end

--- a/zohoho.gemspec
+++ b/zohoho.gemspec
@@ -5,7 +5,7 @@
 
 Gem::Specification.new do |s|
   s.name = %q{zohoho}
-  s.version = "0.3.3"
+  s.version = "0.4.0"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["KentonWhite", "NicholasMartin"]


### PR DESCRIPTION
Update the Zoho objects to accept custom fields when initialized. Previously this required using them as hashes after initialization.